### PR TITLE
Unique Constraints is added to news_create_table

### DIFF
--- a/backup/news_create_table.sql
+++ b/backup/news_create_table.sql
@@ -9,4 +9,5 @@ CREATE TABLE news (
     internal_source VARCHAR(256),
     media_url TEXT,
     media_copyright VARCHAR(256)
+    CONSTRAINT unique_news UNIQUE (title, abstract)
 );


### PR DESCRIPTION
Added only two fields, such as title and abstract, as they could not be the same 